### PR TITLE
StatHooks Fix for Health Modifications

### DIFF
--- a/Modules/StatHooks.cs
+++ b/Modules/StatHooks.cs
@@ -78,12 +78,13 @@ namespace TILER2 {
                 x=>x.MatchLdcR4(out _));
 
             if(ILFound) {
-                c.EmitDelegate<Func<float, float>>((origHealthMult) => {
-                    return origHealthMult + statMods.healthMultAdd;
-                });
-                c.Index -= 3;
+                c.Index -= 2;
                 c.EmitDelegate<Func<float, float>>((origMaxHealth) => {
                     return origMaxHealth + statMods.baseHealthAdd;
+                });
+                c.Index += 2;
+                c.EmitDelegate<Func<float, float>>((origHealthMult) => {
+                    return origHealthMult + statMods.healthMultAdd;
                 });
             } else {
                 TILER2Plugin._logger.LogError("StatHooks: failed to apply IL patch (health modifier)");


### PR DESCRIPTION
Fix a bug where the IL for adding and multiplying health has a wrong result.

Swapped the order of emitting delegates and slightly moved the cursor addition.